### PR TITLE
Now also support changing the option maxTouchDrift

### DIFF
--- a/js/libs/swiftclick.js
+++ b/js/libs/swiftclick.js
@@ -227,6 +227,16 @@ function SwiftClick (contextEl)
 
 SwiftClick.swiftDictionary = {};
 
+SwiftClick.prototype.setMaxTouchDrift = function (maxTouchDrift)
+{
+    if (typeof maxTouchDrift !== 'number')
+    {
+        throw new TypeError ('expected "maxTouchDrift" to be of type "number"');
+    }
+
+    this.options.maxTouchDrift = maxTouchDrift;
+};
+
 // add an array of node names (strings) for which swift clicks should be synthesized.
 SwiftClick.prototype.addNodeNamesToTrack = function (nodeNamesArray)
 {


### PR DESCRIPTION
Currently withint the touchEnd event, SwiftClick calculates with an offset of 30px to determine whether the user tried to click or drag. 30px is quite a large offset, if we compare this to fastClick for instance (which uses 10px).

A public API was needed to be able to configure this option.