### PR TITLE
🐛 Handle touch cancel event just like touch end.

### DIFF
--- a/src/swiftclick.js
+++ b/src/swiftclick.js
@@ -91,8 +91,8 @@ function SwiftClick (contextEl)
         targetEl.removeEventListener('touchend', touchEndHandler, false);
         targetEl.addEventListener('touchend', touchEndHandler, false);
 
-        targetEl.removeEventListener('touchcancel', touchcancelHandler, false);
-        targetEl.addEventListener('touchcancel', touchcancelHandler, false);
+        targetEl.removeEventListener('touchcancel', touchCancelHandler, false);
+        targetEl.addEventListener('touchcancel', touchCancelHandler, false);
     }
 
     function touchEndHandler (event)
@@ -123,8 +123,8 @@ function SwiftClick (contextEl)
         return false;
     }
 
-    function touchcancelHandler(event) {
-        event.target.removeEventListener('touchcancel', touchcancelHandler, false);
+    function touchCancelHandler(event) {
+        event.target.removeEventListener('touchcancel', touchCancelHandler, false);
 
         _currentlyTrackingTouch = false;
     }

--- a/src/swiftclick.js
+++ b/src/swiftclick.js
@@ -90,8 +90,8 @@ function SwiftClick (contextEl)
         // only add the 'touchend' listener now that we know the element should be tracked.
         targetEl.removeEventListener('touchend', touchEndHandler, false);
         targetEl.removeEventListener('touchcancel', touchEndHandler, false);
-        targetEl.addEventListener('touchend', touchEndHandler, false);
-        targetEl.addEventListener('touchcancel', touchEndHandler, false);
+        targetEl.addEventListener('touchend', touchcancelHandler, false);
+        targetEl.addEventListener('touchcancel', touchcancelHandler, false);
     }
 
     function touchEndHandler (event)
@@ -120,6 +120,14 @@ function SwiftClick (contextEl)
 
         // return false in order to surpress the regular click event.
         return false;
+    }
+
+    function touchcancelHandler(event) {
+        var targetEl = event.target;
+
+        targetEl.removeEventListener('touchcancel', touchcancelHandler, false);
+
+        _currentlyTrackingTouch = false;
     }
 
     function clickHandler (event)

--- a/src/swiftclick.js
+++ b/src/swiftclick.js
@@ -89,7 +89,9 @@ function SwiftClick (contextEl)
 
         // only add the 'touchend' listener now that we know the element should be tracked.
         targetEl.removeEventListener('touchend', touchEndHandler, false);
+        targetEl.removeEventListener('touchcancel', touchEndHandler, false);
         targetEl.addEventListener('touchend', touchEndHandler, false);
+        targetEl.addEventListener('touchcancel', touchEndHandler, false);
     }
 
     function touchEndHandler (event)

--- a/src/swiftclick.js
+++ b/src/swiftclick.js
@@ -89,8 +89,9 @@ function SwiftClick (contextEl)
 
         // only add the 'touchend' listener now that we know the element should be tracked.
         targetEl.removeEventListener('touchend', touchEndHandler, false);
-        targetEl.removeEventListener('touchcancel', touchEndHandler, false);
-        targetEl.addEventListener('touchend', touchcancelHandler, false);
+        targetEl.addEventListener('touchend', touchEndHandler, false);
+
+        targetEl.removeEventListener('touchcancel', touchcancelHandler, false);
         targetEl.addEventListener('touchcancel', touchcancelHandler, false);
     }
 
@@ -123,9 +124,7 @@ function SwiftClick (contextEl)
     }
 
     function touchcancelHandler(event) {
-        var targetEl = event.target;
-
-        targetEl.removeEventListener('touchcancel', touchcancelHandler, false);
+        event.target.removeEventListener('touchcancel', touchcancelHandler, false);
 
         _currentlyTrackingTouch = false;
     }


### PR DESCRIPTION
In scenarios where `touchend` does not get fired but `touchcancel` does, SwiftClick leads to users having to click twice to actually click on an element. So, handling `touchcancel` event just like `touchend` event is necessary.