### PR TITLE
Removed ghost click handler 

### DIFF
--- a/src/swiftclick.js
+++ b/src/swiftclick.js
@@ -91,8 +91,8 @@ function SwiftClick (contextEl)
         targetEl.removeEventListener('touchend', touchEndHandler, false);
         targetEl.addEventListener('touchend', touchEndHandler, false);
 
-        targetEl.removeEventListener('touchcancel', touchcancelHandler, false);
-        targetEl.addEventListener('touchcancel', touchcancelHandler, false);
+        targetEl.removeEventListener('touchcancel', touchCancelHandler, false);
+        targetEl.addEventListener('touchcancel', touchCancelHandler, false);
     }
 
     function touchEndHandler (event)
@@ -123,8 +123,8 @@ function SwiftClick (contextEl)
         return false;
     }
 
-    function touchcancelHandler(event) {
-        event.target.removeEventListener('touchcancel', touchcancelHandler, false);
+    function touchCancelHandler(event) {
+        event.target.removeEventListener('touchcancel', touchCancelHandler, false);
 
         _currentlyTrackingTouch = false;
     }

--- a/src/swiftclick.js
+++ b/src/swiftclick.js
@@ -26,7 +26,6 @@ function SwiftClick (contextEl)
     var _currentlyTrackingTouch         = false;
     var _touchStartPoint                = {x:0, y:0};
     var _scrollStartPoint               = {x:0, y:0};
-    var _clickedAlready                 = false;
 
 
     // SwiftClick is only initialised if both touch and orientationchange are supported.
@@ -45,7 +44,6 @@ function SwiftClick (contextEl)
         }
 
         _swiftContextEl.addEventListener('touchstart', touchStartHandler, false);
-        _swiftContextEl.addEventListener('click', clickHandler, true);
     }
 
     function hijackedSwiftElClickHandler (event)
@@ -74,7 +72,6 @@ function SwiftClick (contextEl)
         // check parents for 'swiftclick-ignore' class name.
         if (_self.options.useCssParser && checkIfElementShouldBeIgnored(targetEl))
         {
-            _clickedAlready = false;
             return true;
         }
 
@@ -114,8 +111,6 @@ function SwiftClick (contextEl)
         event.stopPropagation();
         event.preventDefault();
 
-        _clickedAlready = false;
-
         targetEl.focus();
         synthesizeClickEvent(targetEl, touchend);
 
@@ -127,26 +122,6 @@ function SwiftClick (contextEl)
         event.target.removeEventListener('touchcancel', touchCancelHandler, false);
 
         _currentlyTrackingTouch = false;
-    }
-
-    function clickHandler (event)
-    {
-        var targetEl = event.target;
-        var nodeName = targetEl.nodeName.toLowerCase();
-
-        if (typeof _self.options.elements[nodeName] !== 'undefined')
-        {
-            if (_clickedAlready)
-            {
-                _clickedAlready = false;
-
-                event.stopPropagation();
-                event.preventDefault();
-                return false;
-            }
-
-            _clickedAlready = true;
-        }
     }
 
     function synthesizeClickEvent (el, touchend)

--- a/src/swiftclick.js
+++ b/src/swiftclick.js
@@ -90,8 +90,8 @@ function SwiftClick (contextEl)
         // only add the 'touchend' listener now that we know the element should be tracked.
         targetEl.removeEventListener('touchend', touchEndHandler, false);
         targetEl.removeEventListener('touchcancel', touchEndHandler, false);
-        targetEl.addEventListener('touchend', touchEndHandler, false);
-        targetEl.addEventListener('touchcancel', touchEndHandler, false);
+        targetEl.addEventListener('touchend', touchcancelHandler, false);
+        targetEl.addEventListener('touchcancel', touchcancelHandler, false);
     }
 
     function touchEndHandler (event)
@@ -120,6 +120,14 @@ function SwiftClick (contextEl)
 
         // return false in order to surpress the regular click event.
         return false;
+    }
+
+    function touchcancelHandler(event) {
+        var targetEl = event.target;
+
+        targetEl.removeEventListener('touchcancel', touchcancelHandler, false);
+
+        _currentlyTrackingTouch = false;
     }
 
     function clickHandler (event)

--- a/src/swiftclick.js
+++ b/src/swiftclick.js
@@ -89,7 +89,9 @@ function SwiftClick (contextEl)
 
         // only add the 'touchend' listener now that we know the element should be tracked.
         targetEl.removeEventListener('touchend', touchEndHandler, false);
+        targetEl.removeEventListener('touchcancel', touchEndHandler, false);
         targetEl.addEventListener('touchend', touchEndHandler, false);
+        targetEl.addEventListener('touchcancel', touchEndHandler, false);
     }
 
     function touchEndHandler (event)

--- a/src/swiftclick.js
+++ b/src/swiftclick.js
@@ -89,8 +89,9 @@ function SwiftClick (contextEl)
 
         // only add the 'touchend' listener now that we know the element should be tracked.
         targetEl.removeEventListener('touchend', touchEndHandler, false);
-        targetEl.removeEventListener('touchcancel', touchEndHandler, false);
-        targetEl.addEventListener('touchend', touchcancelHandler, false);
+        targetEl.addEventListener('touchend', touchEndHandler, false);
+
+        targetEl.removeEventListener('touchcancel', touchcancelHandler, false);
         targetEl.addEventListener('touchcancel', touchcancelHandler, false);
     }
 
@@ -123,9 +124,7 @@ function SwiftClick (contextEl)
     }
 
     function touchcancelHandler(event) {
-        var targetEl = event.target;
-
-        targetEl.removeEventListener('touchcancel', touchcancelHandler, false);
+        event.target.removeEventListener('touchcancel', touchcancelHandler, false);
 
         _currentlyTrackingTouch = false;
     }


### PR DESCRIPTION
Like we discussed, ghost click handler is no-longer necessary and causes problems with automated tests. Tested on iOS. Have not tested in Android devices. 